### PR TITLE
Refactor idenfy client to use net/http instead of fasthttp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/swag v1.16.3
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20241007205731-5e76664a3cc4
-	github.com/valyala/fasthttp v1.51.0
 	github.com/vedhavyas/go-subkey/v2 v2.0.0
 	go.mongodb.org/mongo-driver v1.17.1
 )
@@ -61,6 +60,7 @@ require (
 	github.com/swaggo/files/v2 v2.0.0 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.51.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/internal/clients/idenfy/idenfy.go
+++ b/internal/clients/idenfy/idenfy.go
@@ -7,6 +7,7 @@ This layer is responsible for interacting with the iDenfy API. the main operatio
 package idenfy
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -15,89 +16,59 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/threefoldtech/tf-kyc-verifier/internal/models"
-	"github.com/valyala/fasthttp"
 )
 
 type Idenfy struct {
-	client *fasthttp.Client // TODO: Interface
-	config IdenfyConfig     // TODO: Interface
+	client *http.Client
+	config IdenfyConfig
 	logger *slog.Logger
 }
 
 const (
 	VerificationSessionEndpoint = "/api/v2/token"
+	TokenExpirySeconds          = 86400
+	TokenExpiryDevModeSeconds   = 30
+	DefaultTimeout              = 10 * time.Second
+	ContentTypeJSON             = "application/json"
 )
 
 func New(config IdenfyConfig, logger *slog.Logger) *Idenfy {
 	return &Idenfy{
-		client: &fasthttp.Client{},
+		client: &http.Client{
+			Timeout: DefaultTimeout,
+		},
 		config: config,
 		logger: logger,
 	}
 }
 
-func (c *Idenfy) CreateVerificationSession(ctx context.Context, clientID string) (models.Token, error) { // TODO: Refactor
-	url := c.config.GetBaseURL() + VerificationSessionEndpoint
-
-	req := fasthttp.AcquireRequest()
-	defer fasthttp.ReleaseRequest(req)
-
-	req.SetRequestURI(url)
-	req.Header.SetMethod(fasthttp.MethodPost)
-	req.Header.Set("Content-Type", "application/json")
-
-	// Set basic auth
-	authStr := c.config.GetAPIKey() + ":" + c.config.GetAPISecret()
-	auth := base64.StdEncoding.EncodeToString([]byte(authStr))
-	req.Header.Set("Authorization", "Basic "+auth)
-
-	RequestBody := c.createVerificationSessionRequestBody(clientID, c.config.GetDevMode())
-
-	jsonBody, err := json.Marshal(RequestBody)
+func (c *Idenfy) CreateVerificationSession(ctx context.Context, clientID string) (models.Token, error) {
+	req, err := c.prepareRequest(ctx, clientID, TokenExpirySeconds)
 	if err != nil {
-		return models.Token{}, fmt.Errorf("marshaling request body: %w", err)
-	}
-	req.SetBody(jsonBody)
-	// Set deadline from context
-	deadline, ok := ctx.Deadline()
-	if ok {
-		req.SetTimeout(time.Until(deadline))
+		return models.Token{}, fmt.Errorf("preparing request: %w", err)
 	}
 
-	resp := fasthttp.AcquireResponse()
-	defer fasthttp.ReleaseResponse(resp)
-	c.logger.Debug("Preparing iDenfy verification session request", "request", jsonBody)
-	err = c.client.Do(req, resp)
+	resp, err := c.client.Do(req)
 	if err != nil {
-		return models.Token{}, fmt.Errorf("sending token request to iDenfy: %w", err)
+		return models.Token{}, fmt.Errorf("sending request: %w", err)
 	}
+	defer resp.Body.Close()
 
-	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
-		c.logger.Debug("Received unexpected status code from iDenfy", "status", resp.StatusCode(), "error", string(resp.Body()))
-		return models.Token{}, fmt.Errorf("unexpected status code from iDenfy: %d", resp.StatusCode())
-	}
-	c.logger.Debug("Received response from iDenfy", "response", string(resp.Body()))
-
-	var result models.Token
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		return models.Token{}, fmt.Errorf("decoding token response from iDenfy: %w", err)
-	}
-
-	return result, nil
+	return c.handleResponse(resp)
 }
 
-// verify signature of the callback
 func (c *Idenfy) VerifyCallbackSignature(ctx context.Context, body []byte, sigHeader string) error {
 	sig, err := hex.DecodeString(sigHeader)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid signature format: %w", err)
 	}
 	mac := hmac.New(sha256.New, []byte(c.config.GetCallbackSignKey()))
-
 	mac.Write(body)
 
 	if !hmac.Equal(sig, mac.Sum(nil)) {
@@ -106,16 +77,86 @@ func (c *Idenfy) VerifyCallbackSignature(ctx context.Context, body []byte, sigHe
 	return nil
 }
 
-// function to create a request body for the verification session
-func (c *Idenfy) createVerificationSessionRequestBody(clientID string, devMode bool) map[string]interface{} {
-	RequestBody := map[string]interface{}{
-		"clientId":            clientID,
-		"generateDigitString": true,
-		"callbackUrl":         c.config.GetCallbackUrl(),
+func (c *Idenfy) prepareRequest(ctx context.Context, clientID string, tokenExpiryTime int) (*http.Request, error) {
+	body, err := c.createRequestBody(clientID, tokenExpiryTime)
+	if err != nil {
+		return nil, fmt.Errorf("creating request body: %w", err)
+	}
+
+	url := c.config.GetBaseURL() + VerificationSessionEndpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	c.setRequestHeaders(req)
+	return req, nil
+}
+
+func (c *Idenfy) createRequestBody(clientID string, tokenExpiryTime int) ([]byte, error) {
+	requestBody := c.createVerificationSessionRequestBody(clientID, c.config.GetDevMode(), tokenExpiryTime)
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request body: %w", err)
+	}
+	return jsonBody, nil
+}
+
+func (c *Idenfy) setRequestHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", ContentTypeJSON)
+	authStr := c.config.GetAPIKey() + ":" + c.config.GetAPISecret()
+	auth := base64.StdEncoding.EncodeToString([]byte(authStr))
+	req.Header.Set("Authorization", "Basic "+auth)
+}
+
+func (c *Idenfy) handleResponse(resp *http.Response) (models.Token, error) {
+	if err := c.validateResponseStatus(resp); err != nil {
+		return models.Token{}, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return models.Token{}, fmt.Errorf("reading response body: %w", err)
+	}
+
+	var result models.Token
+	if err := json.Unmarshal(body, &result); err != nil {
+		return models.Token{}, fmt.Errorf("decoding token response from iDenfy: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *Idenfy) validateResponseStatus(resp *http.Response) error {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		c.logger.Debug("Received unexpected status code from iDenfy",
+			"status", resp.StatusCode,
+			"error", string(body),
+		)
+		return fmt.Errorf("unexpected status code from iDenfy: code: %d, body: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+type VerificationSessionRequest struct {
+	ClientID            string `json:"clientId"`
+	GenerateDigitString bool   `json:"generateDigitString"`
+	CallbackURL         string `json:"callbackUrl"`
+	ExpiryTime          int    `json:"expiryTime"`
+	DummyStatus         string `json:"dummyStatus,omitempty"`
+}
+
+func (c *Idenfy) createVerificationSessionRequestBody(clientID string, devMode bool, tokenExpiryTime int) *VerificationSessionRequest {
+	RequestBody := &VerificationSessionRequest{
+		ClientID:            clientID,
+		GenerateDigitString: true,
+		CallbackURL:         c.config.GetCallbackUrl(),
+		ExpiryTime:          tokenExpiryTime,
 	}
 	if devMode {
-		RequestBody["expiryTime"] = 30
-		RequestBody["dummyStatus"] = "APPROVED"
+		RequestBody.ExpiryTime = TokenExpiryDevModeSeconds
+		RequestBody.DummyStatus = "APPROVED"
 	}
 	return RequestBody
 }


### PR DESCRIPTION
**Changes:**
- Refactoring the logic into smaller functions
- switch to the default HTTP client instead of fastHttp

**Related Issues:**
- fixes #8 

Notes: To be followed with more work to evaluate/switch from Go Fiber framework to a more mature solution per @xmonader request 