### PR TITLE
Feat: Add alwaysVerifiedIDsOnly Option

### DIFF
--- a/.app.env.example
+++ b/.app.env.example
@@ -21,3 +21,4 @@ DEBUG=false
 IDENFY_CALLBACK_URL=https://kyc.dev.grid.tf/webhooks/idenfy/verification-update
 IDENFY_NAMESPACE=
 VERIFICATION_ALWAYS_VERIFIED_IDS=
+VERIFICATION_ALWAYS_VERIFIED_IDS_ONLY=false

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The application uses environment variables for configuration. Here's a list of a
 - `VERIFICATION_EXPIRED_DOCUMENT_OUTCOME`: Outcome for expired documents (default: "REJECTED")
 - `VERIFICATION_MIN_BALANCE_TO_VERIFY_ACCOUNT`: Minimum balance in unitTFT required to verify an account (default: 10000000)
 - `VERIFICATION_ALWAYS_VERIFIED_IDS`: Comma-separated list of TFChain SS58Addresses that are always verified (default: "")
+- `VERIFICATION_ALWAYS_VERIFIED_IDS`: When the AlwaysVerifiedIDsOnly is true, the creation of KYC tokens is disabled on this network (default: false)
 
 ### Rate Limiting
 
@@ -168,6 +169,7 @@ To run the application locally:
     - `400`: Bad request
     - `401`: Unauthorized
     - `402`: Payment required
+    - `403`: Forbidden
     - `409`: Conflict
 
 #### Verification

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ type Verification struct {
 	ExpiredDocumentOutcome        string   `env:"VERIFICATION_EXPIRED_DOCUMENT_OUTCOME" env-default:"REJECTED"`
 	MinBalanceToVerifyAccount     uint64   `env:"VERIFICATION_MIN_BALANCE_TO_VERIFY_ACCOUNT" env-default:"10000000"`
 	AlwaysVerifiedIDs             []string `env:"VERIFICATION_ALWAYS_VERIFIED_IDS" env-separator:","`
+	AlwaysVerifiedIDsOnly         bool     `env:"VERIFICATION_ALWAYS_VERIFIED_IDS_ONLY" env-default:"false"`
 }
 type IPLimiter struct {
 	MaxTokenRequests uint `env:"IP_LIMITER_MAX_TOKEN_REQUESTS" env-default:"4"`
@@ -155,6 +156,10 @@ func (c *Config) Validate() error {
 	// ExpiredDocumentOutcome should be either APPROVED or REJECTED
 	if !slices.Contains([]string{"APPROVED", "REJECTED"}, c.Verification.ExpiredDocumentOutcome) {
 		return errors.New("invalid ExpiredDocumentOutcome. should be either APPROVED or REJECTED")
+	}
+	// AlwaysVerifiedIDsOnly cannot be true if the AlwaysVerifiedIDs list is empty
+	if c.Verification.AlwaysVerifiedIDsOnly && len(c.Verification.AlwaysVerifiedIDs) == 0 {
+		return errors.New("AlwaysVerifiedIDsOnly cannot be true if the AlwaysVerifiedIDs list is empty. Either set AlwaysVerifiedIDsOnly to false, or add at least one allowed ID to the AlwaysVerifiedIDs list")
 	}
 	// MinBalanceToVerifyAccount
 	if c.Verification.MinBalanceToVerifyAccount < 20000000 {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -13,6 +13,7 @@ const (
 	// Error types
 	ErrorTypeValidation           ErrorType = "VALIDATION_ERROR"
 	ErrorTypeAuthorization        ErrorType = "AUTHORIZATION_ERROR"
+	ErrorTypeForbidden            ErrorType = "FORBIDDEN"
 	ErrorTypeNotFound             ErrorType = "NOT_FOUND"
 	ErrorTypeConflict             ErrorType = "CONFLICT"
 	ErrorTypeInternal             ErrorType = "INTERNAL_ERROR"
@@ -86,6 +87,14 @@ func NewExternalError(msg string, err error) *ServiceError {
 func NewNotSufficientBalanceError(msg string, err error) *ServiceError {
 	return &ServiceError{
 		Type: ErrorTypeNotSufficientBalance,
+		Msg:  msg,
+		Err:  err,
+	}
+}
+
+func NewForbiddenError(msg string, err error) *ServiceError {
+	return &ServiceError{
+		Type: ErrorTypeForbidden,
 		Msg:  msg,
 		Err:  err,
 	}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -320,6 +320,8 @@ func getStatusCode(errorType errors.ErrorType) int {
 		return fiber.StatusServiceUnavailable
 	case errors.ErrorTypeNotSufficientBalance:
 		return fiber.StatusPaymentRequired
+	case errors.ErrorTypeForbidden:
+		return fiber.StatusForbidden
 	default:
 		return fiber.StatusInternalServerError
 	}

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -73,6 +73,7 @@ func NewHandler(kycService *services.KYCService, config *config.Config, logger *
 // @Failure		400			{object}		object{error=string}
 // @Failure		401			{object}		object{error=string}
 // @Failure		402			{object}		object{error=string}
+// @Failure		403			{object}		object{error=string}
 // @Failure		409			{object}		object{error=string}
 // @Failure		500			{object}		object{error=string}
 // @Failure		503			{object}		object{error=string}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -166,6 +166,9 @@ func (s *KYCService) GetVerificationStatus(ctx context.Context, clientID string)
 			Outcome:   models.OutcomeApproved,
 		}, nil
 	}
+	if s.config.AlwaysVerifiedIDsOnly {
+		return nil, nil
+	}
 	verification, err := s.verificationRepo.GetVerification(ctx, clientID)
 	if err != nil {
 		s.logger.Error("Error getting verification from database", "clientID", clientID, "error", err)

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -68,15 +68,18 @@ func (s *KYCService) GetOrCreateVerificationToken(ctx context.Context, clientID 
 	isVerified, err := s.IsUserVerified(ctx, clientID)
 	if err != nil {
 		s.logger.Error("Error checking if user is verified", "clientID", clientID, "error", err)
-		return nil, false, errors.NewInternalError("getting verification status from database", err) // db error
+		return nil, false, errors.NewInternalError("getting verification status from database", err)
 	}
 	if isVerified {
-		return nil, false, errors.NewConflictError("user already verified", nil) // TODO: implement a custom error that can be converted in the handler to a 4xx such 409 status code
+		return nil, false, errors.NewConflictError("user already verified", nil)
+	}
+	if s.config.AlwaysVerifiedIDsOnly {
+		return nil, false, errors.NewForbiddenError("You don’t have permission to access the KYC service while AlwaysVerifiedIDsOnly mode is active. Please contact support.", nil)
 	}
 	token, err_ := s.tokenRepo.GetToken(ctx, clientID)
 	if err_ != nil {
 		s.logger.Error("Error getting token from database", "clientID", clientID, "error", err_)
-		return nil, false, errors.NewInternalError("getting token from database", err_) // db error
+		return nil, false, errors.NewInternalError("getting token from database", err_)
 	}
 	// check if token is found and not expired
 	if token != nil {

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -74,7 +74,8 @@ func (s *KYCService) GetOrCreateVerificationToken(ctx context.Context, clientID 
 		return nil, false, errors.NewConflictError("user already verified", nil)
 	}
 	if s.config.AlwaysVerifiedIDsOnly {
-		return nil, false, errors.NewForbiddenError("You don’t have permission to access the KYC service while AlwaysVerifiedIDsOnly mode is active. Please contact support.", nil)
+		// If AlwaysVerifiedIDsOnly mode is active, KYC token creation is disabled on this network.
+		return nil, false, errors.NewForbiddenError("KYC is disabled while AlwaysVerifiedIDsOnly mode is active", nil)
 	}
 	token, err_ := s.tokenRepo.GetToken(ctx, clientID)
 	if err_ != nil {


### PR DESCRIPTION
**What's Changed:**

- A new configurable option/environment variable called `AlwaysVerifiedIDsOnly` has been added to activate the `AlwaysVerifiedIDsOnly` mode. It is Disabled by default.
- When the `AlwaysVerifiedIDsOnly` mode is active, the creation of KYC tokens is disabled on this network.
- Any attempts to generate new verification tokens will result in a 403 FORBIDDEN error, accompanied by a detailed message.
- Previously verified users will become unverified if they are not included in the `alwaysAllowedIDs` list.

**Related Issues:**
- https://github.com/threefoldtech/tf-kyc-verifier/issues/25